### PR TITLE
kustomize: use quay.io image for the default deployment

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,5 +28,5 @@ patchesStrategicMerge:
 
 images:
 - name: controller
-  newName: docker.pkg.github.com/daimler/cluster-api-state-metrics/cluster-api-state-metrics
+  newName: quay.io/cluster-api-state-metrics/cluster-api-state-metrics
   newTag: latest


### PR DESCRIPTION
ghcr.io requires authentication, it's easier to pull from quay.

part of #3

Signed-off-by: Schlotter, Christian <christian.schlotter@daimler.com>

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Provider Information</a>
</sup>