### PR TITLE
ci/foss-scan: fix

### DIFF
--- a/.github/workflows/foss.yaml
+++ b/.github/workflows/foss.yaml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
-    branches:
-    - main
 
 env:
   GO_VERSION: "^1.17"
@@ -33,7 +30,6 @@ jobs:
         GITHUB_REF="$(echo $GITHUB_REF_NAME | tr ':/' '_')"
         BLACKDUCK_SCAN_VERSION_NAME="${GITHUB_REF}_${GITHUB_SHA}"
         export BLACKDUCK_SCAN_VERSION_NAME
-        echo "BLACKDUCK_SCAN_VERSION_NAME=${BLACKDUCK_SCAN_VERSION_NAME}"
 
         ./hack/foss-scan.sh bdscan.txt bdscan.notices.txt
       env:

--- a/.github/workflows/foss.yaml
+++ b/.github/workflows/foss.yaml
@@ -30,9 +30,10 @@ jobs:
 
     - name: Synopsys Detect
       run: |
-        GITHUB_REF="$(echo $GITHUB_REF_NAME | tr '/' '_')"
+        GITHUB_REF="$(echo $GITHUB_REF_NAME | tr ':/' '_')"
         BLACKDUCK_SCAN_VERSION_NAME="${GITHUB_REF}_${GITHUB_SHA}"
         export BLACKDUCK_SCAN_VERSION_NAME
+        echo "BLACKDUCK_SCAN_VERSION_NAME=${BLACKDUCK_SCAN_VERSION_NAME}"
 
         ./hack/foss-scan.sh bdscan.txt bdscan.notices.txt
       env:

--- a/hack/foss-scan.sh
+++ b/hack/foss-scan.sh
@@ -97,7 +97,7 @@ bash <(curl -s -L https://detect.synopsys.com/detect.sh) \
 	--insecure
 RC=$?
 
-Delete the scan if it completed successfully.
+# Delete the scan if it completed successfully.
 if [[ ${RC} == 0 ]]; then
 	try_delete_version "${BLACKDUCK_SCAN_VERSION_NAME}" "${bearer_token}" "${project_url}"
 fi


### PR DESCRIPTION
* Fixes text in `hack/foss-scan.sh` which should be a comment
* Also replace colons when defining the blackduck scan version name
* Remove foss scann from PRs because the gh secrets do not get provided to the action 

Signed-off-by: Schlotter, Christian <christian.schlotter@daimler.com>